### PR TITLE
Update default url option's value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ searchControl.addTo(map);
 ```
 
 ## Options
-- `url` URL of the Photon API to use. *Default: 'http://photon.komoot.de/api/?'*
+- `url` URL of the Photon API to use. *Default: 'https://photon.komoot.de/api/?'*
 - `placeholder` Placeholder of the search input. *Default: "Start typing..."*
 - `noResultLabel` Message to display when no result has been found. *Default: "No result"*
 - `minChar` Min char to be typed before actually searching (can be a function that


### PR DESCRIPTION
Change http to https to match the source code (http does not seem to work anymore, anyway).