### PR TITLE
Better display for name-less addresses

### DIFF
--- a/leaflet.photon.js
+++ b/leaflet.photon.js
@@ -245,7 +245,14 @@ L.PhotonBaseSearch = L.PhotonBase.extend({
             detailsContainer = L.DomUtil.create('small', '', el),
             details = [],
             type = this.formatType(feature);
-        title.innerHTML = feature.properties.name;
+        if (feature.properties.name) {
+            title.innerHTML = feature.properties.name;
+        } else if (feature.properties.housenumber) {
+            title.innerHTML = feature.properties.housenumber;
+            if (feature.properties.street) {
+                title.innerHTML += ' ' + feature.properties.street;
+            }
+        }
         if (type) details.push(type);
         if (feature.properties.city && feature.properties.city !== feature.properties.name) {
             details.push(feature.properties.city);


### PR DESCRIPTION
Pure addresses are returned by photon without a name. The result is that the suggestion list just displays 'undefined' for addresses. This PR catches these cases and formats them as <housenumber> <street>. As a side effect the title is now empty when neither name nor housenumber can be found in the result. I don't know if that case exists.