### PR TITLE
Use osm_key for type when osm_value is yes

### DIFF
--- a/leaflet.photon.js
+++ b/leaflet.photon.js
@@ -263,7 +263,9 @@ L.PhotonBaseSearch = L.PhotonBase.extend({
     },
 
     _formatType: function (feature) {
-        return feature.properties.osm_value;
+        return feature.properties.osm_value === 'yes'
+               ? feature.properties.osm_key
+               : feature.properties.osm_value;
     },
 
     createResult: function (feature) {


### PR DESCRIPTION
OSM objects often feature generic <key>=yes descriptions
most notably for building=yes. In that case osm_value is
not very useful as a type description. Use osm_key instead.